### PR TITLE
feat: 사용자 역할 분리 및 검증 로직 추가 (#37)

### DIFF
--- a/src/main/java/goorm/_44/common/exception/ErrorCode.java
+++ b/src/main/java/goorm/_44/common/exception/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode {
     INSUFFICIENT_STAMPS(HttpStatus.BAD_REQUEST, "스탬프가 부족하여 쿠폰을 사용할 수 없습니다."),
 
     // 403 FORBIDDEN
-    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     // 404 NOT FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/goorm/_44/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/goorm/_44/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,8 @@
+package goorm._44.dto.request;
+
+import goorm._44.entity.Role;
+
+public record KakaoLoginRequest(
+        String code,
+        Role role
+) {}

--- a/src/main/java/goorm/_44/entity/Role.java
+++ b/src/main/java/goorm/_44/entity/Role.java
@@ -1,0 +1,6 @@
+package goorm._44.entity;
+
+public enum Role {
+    REGULAR, // 단골
+    OWNER    // 사장님
+}

--- a/src/main/java/goorm/_44/entity/User.java
+++ b/src/main/java/goorm/_44/entity/User.java
@@ -21,16 +21,14 @@ public class User extends BaseEntity {
     private String name;
 
     @Column
-    private String phone;
-
-    @Column
     private String region;
 
     @Column
     private String password;
 
     @Column
-    private String role; // "OWNER", "CUSTOMER"
+    @Enumerated(EnumType.STRING)
+    private Role role;  // REGULAR / OWNER
 
     @Column
     private String profileImageUrl;

--- a/src/main/java/goorm/_44/repository/UserRepository.java
+++ b/src/main/java/goorm/_44/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package goorm._44.repository;
 
+import goorm._44.entity.Role;
 import goorm._44.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,6 +8,8 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByName(String username);
-    Optional<User> findByRole(String role);
     Optional<User> findByPassword(String password);
+
+    Optional<User> findByPasswordAndRole(String password, Role role);
+
 }

--- a/src/main/java/goorm/_44/service/noti/NotiService.java
+++ b/src/main/java/goorm/_44/service/noti/NotiService.java
@@ -40,9 +40,7 @@ public class NotiService {
     @Transactional
     public Long createNoti(NotiCreateRequest req, Long userId) {
         // 1. 사장 검증
-        // TODO : 사장 검증 로직 필요
-        User owner = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User owner = validateOwner(userId);
 
         // 2. 사장 가게 조회
         Store store = storeRepository.findByUserId(userId).stream()
@@ -77,9 +75,7 @@ public class NotiService {
     @Transactional(readOnly = true)
     public PageResponse<NotiLogResponse> getNotiLogs(Long userId, Integer page, Integer size) {
         // 1. 사장 검증
-        // TODO : 사장 검증 로직 필요
-        User owner = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User owner = validateOwner(userId);
 
         // 2. 사장 가게 조회
         Store store = storeRepository.findByUserId(userId).stream()
@@ -129,9 +125,7 @@ public class NotiService {
     @Transactional
     public void readNoti(Long userId, Long notiId) {
         // 1. 단골 검증
-        // TODO : 사장 검증 로직 필요
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = validateRegular(userId);
 
         Noti noti = notiRepository.findById(notiId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOTI_NOT_FOUND));
@@ -143,5 +137,27 @@ public class NotiService {
                 .build();
 
         notiReadRepository.save(notiRead);
+    }
+
+    private User validateOwner(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getRole() != Role.OWNER) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        return user;
+    }
+
+    private User validateRegular(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getRole() != Role.REGULAR) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        return user;
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
카카오 로그인 시 단골(REGULAR)과 사장님(OWNER) 역할을 분리한다.
로그인 후 요청 시, 해당 역할에 맞는 권한을 검증하는 로직을 추가한다.

## 🛠 상세 작업 항목
- [x] 카카오 로그인 시 역할 분리
- [x] 역할 검증 로직 추가