### PR TITLE
feat: 방문·적립 추이 차트 기능 추가 (#50)

### DIFF
--- a/src/main/java/goorm/_44/controller/stamp/StampController.java
+++ b/src/main/java/goorm/_44/controller/stamp/StampController.java
@@ -43,7 +43,19 @@ public class StampController {
         );
     }
 
+    @GetMapping("/me/visit-trends/daily")
+    @Operation(summary = "[사장] 일간 방문·적립 추이 조회", description = "사용자의 가게 일간 방문·적립 추이를 조회합니다.")
+    public ApiResult<List<VisitTrendResponse.TimeSegment>> getDailyVisitTrends(Authentication auth) {
+        Long userId = Long.parseLong(auth.getName());
+        return ApiResult.success(stampService.getDailyVisitStats(userId));
+    }
 
+    @GetMapping("/me/visit-trends/weekly")
+    @Operation(summary = "[사장] 주간 방문·적립 추이 조회", description = "사용자의 가게 주간 방문·적립 추이를 조회합니다.")
+    public ApiResult<List<VisitTrendResponse.DailyStat>> getWeeklyVisitTrends(Authentication auth) {
+        Long userId = Long.parseLong(auth.getName());
+        return ApiResult.success(stampService.getWeeklyVisitStats(userId));
+    }
 
 
     @GetMapping("/me/main")
@@ -70,7 +82,7 @@ public class StampController {
 
 
     @GetMapping("/recommend")
-    @Operation(summary = "추천 가게 조회", description = "가장 자주 찾는 카테고리를 기반으로 가게를 추천합니다.")
+    @Operation(summary = "[단골] 추천 가게 조회", description = "가장 자주 찾는 카테고리를 기반으로 가게를 추천합니다.")
     public ApiResult<RecommendResponse> recommendStore(Authentication authentication) {
         Long userId = Long.parseLong(authentication.getName());
         RecommendResponse response = stampService.recommendCategoryStore(userId);

--- a/src/main/java/goorm/_44/controller/stamp/StampController.java
+++ b/src/main/java/goorm/_44/controller/stamp/StampController.java
@@ -91,7 +91,7 @@ public class StampController {
     }
 
 
-    @GetMapping("me/stores/{storeId}")
+    @GetMapping("/me/stores/{storeId}")
     @Operation(summary = "[단골] 단골 가게 상세 조회", description = "단골 가게 상세 정보와 최신 공지를 조회합니다.")
     public ApiResult<StoreDetailResponse> getStoreDetail(
             @PathVariable Long storeId,

--- a/src/main/java/goorm/_44/controller/store/StoreController.java
+++ b/src/main/java/goorm/_44/controller/store/StoreController.java
@@ -5,6 +5,7 @@ import goorm._44.dto.request.StoreCreateRequest;
 import goorm._44.dto.response.DashboardResponse;
 import goorm._44.dto.response.IdResponse;
 import goorm._44.dto.response.StoreResponse;
+import goorm._44.dto.response.VisitTrendResponse;
 import goorm._44.service.store.InsightService;
 import goorm._44.service.store.StoreService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/stores")

--- a/src/main/java/goorm/_44/dto/response/VisitTrendResponse.java
+++ b/src/main/java/goorm/_44/dto/response/VisitTrendResponse.java
@@ -1,0 +1,24 @@
+package goorm._44.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record VisitTrendResponse(
+        List<TimeSegment> daily,
+        List<DailyStat> weekly
+) {
+    public static record TimeSegment(
+            int startHour,
+            int endHour,
+            int totalVisitors,
+            int newVisitors,
+            int revisits
+    ) {}
+
+    public static record DailyStat(
+            LocalDate date,
+            int totalVisitors,
+            int newVisitors,
+            int revisits
+    ) {}
+}

--- a/src/main/java/goorm/_44/repository/StampLogRepository.java
+++ b/src/main/java/goorm/_44/repository/StampLogRepository.java
@@ -96,4 +96,23 @@ public interface StampLogRepository extends JpaRepository<StampLog, Long> {
             "AND DATE(s.updatedAt) = :date")
     int countReRegularsByDate(@Param("storeId") Long storeId, @Param("date") LocalDate date);
 
+
+
+    @Query("""
+        SELECT COUNT(DISTINCT sl.stamp.user.id)
+        FROM StampLog sl
+        WHERE sl.store.id = :storeId
+          AND DATE(sl.createdAt) = :date
+          AND HOUR(sl.createdAt) >= :startHour
+          AND HOUR(sl.createdAt) < :endHour
+          AND sl.action IN :actions
+    """)
+    int countDistinctUsersByStoreAndDateTimeRange(
+            @Param("storeId") Long storeId,
+            @Param("date") LocalDate date,
+            @Param("startHour") int startHour,
+            @Param("endHour") int endHour,
+            @Param("actions") List<StampAction> actions
+    );
+
 }

--- a/src/main/java/goorm/_44/service/stamp/StampService.java
+++ b/src/main/java/goorm/_44/service/stamp/StampService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -121,6 +122,115 @@ public class StampService {
         );
         }
 
+
+    /**
+     * [사장] 일간 방문·적립 추이 조회
+     */
+    @Transactional(readOnly = true)
+    public VisitTrendResponse getVisitTrends(Long userId) {
+        User owner = validateOwner(userId);
+
+        Store store = storeRepository.findByUserId(userId).stream()
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+
+        return new VisitTrendResponse(
+                getDailyVisitStats(store),
+                getWeeklyVisitStats(store)
+        );
+    }
+
+
+    /**
+     * [사장] 주간 방문·적립 추이 조회
+     */
+    @Transactional(readOnly = true)
+    public List<VisitTrendResponse.TimeSegment> getDailyVisitStats(Long userId) {
+        User owner = validateOwner(userId);
+
+        Store store = storeRepository.findByUserId(userId).stream()
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+
+        return getDailyVisitStats(store);
+    }
+
+    @Transactional(readOnly = true)
+    public List<VisitTrendResponse.DailyStat> getWeeklyVisitStats(Long userId) {
+        User owner = validateOwner(userId);
+
+        Store store = storeRepository.findByUserId(userId).stream()
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+
+        return getWeeklyVisitStats(store);
+    }
+
+    /* 내부 헬퍼 */
+    private List<VisitTrendResponse.TimeSegment> getDailyVisitStats(Store store) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
+
+        List<VisitTrendResponse.TimeSegment> segments = new ArrayList<>();
+        int[][] ranges = {{0, 6}, {6, 12}, {12, 18}, {18, 24}};
+
+        for (int[] range : ranges) {
+            int startHour = range[0];
+            int endHour = range[1];
+
+            int total = 0;
+            int newUsers = 0;
+            int revisits = 0;
+
+            if (endHour <= now.getHour()) {
+                total = stampLogRepository.countDistinctUsersByStoreAndDateTimeRange(
+                        store.getId(), today, startHour, endHour,
+                        List.of(StampAction.VISIT, StampAction.REGISTER, StampAction.COUPON)
+                );
+                newUsers = stampLogRepository.countDistinctUsersByStoreAndDateTimeRange(
+                        store.getId(), today, startHour, endHour,
+                        List.of(StampAction.REGISTER)
+                );
+                revisits = stampLogRepository.countDistinctUsersByStoreAndDateTimeRange(
+                        store.getId(), today, startHour, endHour,
+                        List.of(StampAction.VISIT, StampAction.COUPON)
+                );
+            }
+
+            segments.add(new VisitTrendResponse.TimeSegment(
+                    startHour, endHour, total, newUsers, revisits
+            ));
+        }
+
+        return segments;
+    }
+
+    private List<VisitTrendResponse.DailyStat> getWeeklyVisitStats(Store store) {
+        LocalDate today = LocalDate.now();
+        List<VisitTrendResponse.DailyStat> stats = new ArrayList<>();
+
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = today.minusDays(i);
+
+            int total = stampLogRepository.countDistinctUsersByStoreAndDateAndActions(
+                    store.getId(), date,
+                    List.of(StampAction.VISIT, StampAction.REGISTER, StampAction.COUPON)
+            );
+            int newUsers = stampLogRepository.countDistinctUsersByStoreAndDateAndAction(
+                    store.getId(), date, StampAction.REGISTER
+            );
+            int revisits = stampLogRepository.countDistinctUsersByStoreAndDateAndActions(
+                    store.getId(), date,
+                    List.of(StampAction.VISIT, StampAction.COUPON)
+            );
+
+            stats.add(new VisitTrendResponse.DailyStat(date, total, newUsers, revisits));
+        }
+
+        return stats.stream()
+                .sorted(Comparator.comparing(VisitTrendResponse.DailyStat::date))
+                .toList();
+    }
 
 
     /**

--- a/src/main/java/goorm/_44/service/store/StoreService.java
+++ b/src/main/java/goorm/_44/service/store/StoreService.java
@@ -4,6 +4,7 @@ import goorm._44.common.exception.CustomException;
 import goorm._44.dto.request.StoreCreateRequest;
 import goorm._44.dto.response.DashboardResponse;
 import goorm._44.dto.response.StoreResponse;
+import goorm._44.dto.response.VisitTrendResponse;
 import goorm._44.entity.*;
 import goorm._44.enums.Role;
 import goorm._44.enums.StampAction;
@@ -16,7 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 


### PR DESCRIPTION
## ✨ 작업 내용
방문·적립 추이 차트 기능을 추가한다.


## 🛠 상세 작업 항목

### 1. 일간 데이터
- **기준**: 당일 00:00 ~ 현재 시간까지
- **시간대 구간**
  - 0 ~ 6시  
  - 6 ~ 12시  
  - 12 ~ 18시  
  - 18 ~ 24시
- **각 구간별 집계 값**
  - 전체 방문자 수
  - 신규 방문자 수
  - 재방문 단골 수
### 2. 주간 데이터
- **기준**: 당일 포함 최근 7일 (오늘 ~ 6일 전)
- **하루 단위 집계 값**
  - 전체 방문자 수
  - 신규 방문자 수
  - 재방문 단골 수
